### PR TITLE
enable recursion using an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,18 @@
 'use strict';
-module.exports = function (obj) {
+module.exports = objectValues;
+
+function objectValues (obj, opts) {
+	opts = opts || {}
 	var keys = Object.keys(obj);
 	var ret = [];
 
 	for (var i = 0; i < keys.length; i++) {
-		ret.push(obj[keys[i]]);
+		var val = obj[keys[i]]
+		if (opts.recurse && val && typeof val === 'object' && Object.keys(val).length) {
+			ret = ret.concat(objectValues(val, opts));
+		} else {
+			ret.push(val);
+		}
 	}
 
 	return ret;

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,18 @@ objectValues({foo: 0, bar: 1});
 //=> [0, 1]
 ```
 
+You can also get values recursively from nested objects
+using the `recurse` option:
+
+```js
+var nestedObj = {
+  a: 'foo',
+  b: {x: 1, y: 2}
+}
+
+objectValues(nestedObj, {recurse: true});
+//=> ['foo', 1, 2]
+```
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,28 @@
 'use strict';
 var assert = require('assert');
 var values = require('./');
+var nestedObject = {
+	a: 'foo',
+	b: {
+		c: 'bar',
+		d: {
+			x: 1,
+			y: 2
+		}
+	}
+};
 
 it('should get the values of an object', function () {
 	assert.deepEqual(values({foo: 'foo', bar: 'bar'}), ['foo', 'bar']);
+});
+
+it('does not recurse nested objects by default', function () {
+	assert.deepEqual(values(nestedObject), [
+		'foo',
+		{c: 'bar', d: {x: 1, y: 2}}
+	]);
+});
+
+it('recurses nested objects if `recurse` option is truthy', function () {
+	assert.deepEqual(values(nestedObject, {recurse: true}), ['foo', 'bar', 1, 2]);
 });


### PR DESCRIPTION
![hulk](https://cloud.githubusercontent.com/assets/2289/20932901/891b3a10-bbd6-11e6-87ad-5447905a7f63.jpeg)

This PR adds support for a `recurse` option for collecting values within nested objects.

This is done without breaking existing functionality, but alternatively we could skip introducing an option and make this the default behavior in a new major version.

cc @sindresorhus 